### PR TITLE
Update to prereq bullet #5

### DIFF
--- a/ci-docs/customer-card-add-in.md
+++ b/ci-docs/customer-card-add-in.md
@@ -28,7 +28,8 @@ Get a 360-degree view of your customers directly in Dynamics 365 apps. With the 
 - For your Dynamics 365 data to map to the Customer Insights customer profiles, we recommend it's [ingested from the Dynamics 365 app using the Microsoft Dataverse connector](connect-power-query.md). If you use a different method to ingest Dynamics 365 contacts (or accounts), make sure the `contactid` (or `accountid`) field is set as the [primary key for that data source during the data unification process](map-entities.md#select-primary-key-and-semantic-type-for-attributes).
 - All Dynamics 365 users of the Customer Card Add-in must be [added as users](permissions.md) in Customer Insights to see the data.
 - [Configured search and filter capabilities](search-filter-index.md) in Customer Insights.
-- Each add-in control relies on specific data in Customer Insights. Some data and controls are only available in environments of specific types. The add-in configuration will inform you if a control isn't available due to the selected environment type. Learn more about [environment use cases](work-with-business-accounts.md).
+- Some data and controls are only available in environments of specific types. The add-in configuration will inform you if a control isn't available due to the selected environment type. This error will show within the control when rendering it. Learn more about [environment use cases](work-with-business-accounts.md).
+- Each add-in control relies on specific data in Customer Insights.
   - **Measure control** requires [configured customer attribute measures](measures.md).
   - **Intelligence control** requires data generated using [predictions or custom models](predictions-overview.md).
   - **Customer details control** shows all fields from the profile available in the unified customer profile.


### PR DESCRIPTION
I've split prerequisite bullet #5 into two: First one is about the instance type only. Here I added a sentence stating where the error will be shown. 2nd bullet is the one about the different controls and what they depend on. My motivation for this split comes from customers struggling to notice that instance types (B2C vs B2B) is a major factor for the card add-in.  I considered grouping the 2nd bullet with in the first, but I doubt it makes a difference worth the cost of having such deep bullet points.